### PR TITLE
Please Upgrade `spring-security-crypto` dependency to the non-vulnerable version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>5.6.2</version>
+            <version>5.6.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
`spring-security-crypto` in 5.6.2 version is affected by vulnerability CVE-2022-22976. Proof of Concept:
the method `` in `helper.PasswordHelper` is affected by CVE-2022-22976 when the input arguments is `("password", "$2a$00$9N8N35BVs5TLqGL3pspAte5OWWA2a2aZIs.EGp7At7txYakFERMue")` , the vulnerability will be triggered, it will throws `java.lang.IllegalArgumentException: Bad number of rounds`